### PR TITLE
feat: support live video analysis for lateral and squat exercises; remove redundant cv2.putText()

### DIFF
--- a/backend/api/lateral_raise.py
+++ b/backend/api/lateral_raise.py
@@ -80,16 +80,6 @@ async def analyze_lateral_frame(payload: FramePayload):
 
         processed_frame, _ = processor.process(frame_rgb, pose)
 
-        cv2.putText(
-            processed_frame,
-            f"Reps: {processor.rep_count}",
-            (50, 50),
-            cv2.FONT_HERSHEY_SIMPLEX,
-            1.0,
-            (0, 255, 0),
-            2
-        )
-
         processed_bgr = processed_frame[..., ::-1]
         success, buffer = cv2.imencode('.jpg', processed_bgr)
         if not success:

--- a/backend/api/squat.py
+++ b/backend/api/squat.py
@@ -1,25 +1,31 @@
-from fastapi import APIRouter, UploadFile, File
-from fastapi.responses import FileResponse, JSONResponse, Response
+import base64
 import tempfile
 import cv2
+import os
 import subprocess
 import numpy as np
-import os
+from fastapi import APIRouter, UploadFile, File
+from fastapi.responses import FileResponse, JSONResponse, Response
+from pydantic import BaseModel
 from core.utils.pose_loader import get_mediapipe_pose
 from core.processors.squat_processor import SquatProcessor
 
 router = APIRouter()
 pose = get_mediapipe_pose()
-squat_processor = SquatProcessor()
+session_store = {}  # In-memory session tracker
+
+class FramePayload(BaseModel):
+    session_id: str
+    image: str  # base64-encoded JPEG image
 
 @router.post("/analyze-video")
-async def analyze_squat(video: UploadFile = File(...)):
+async def analyze_squat_video(video: UploadFile = File(...)):
     try:
         with tempfile.NamedTemporaryFile(delete=False, suffix=".mp4") as temp_vid:
             temp_vid.write(await video.read())
-            temp_input_path = temp_vid.name
+            input_path = temp_vid.name
 
-        cap = cv2.VideoCapture(temp_input_path)
+        cap = cv2.VideoCapture(input_path)
         fps = int(cap.get(cv2.CAP_PROP_FPS)) or 30
         width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH)) or 640
         height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT)) or 480
@@ -27,17 +33,19 @@ async def analyze_squat(video: UploadFile = File(...)):
         raw_output_path = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4").name
         writer = cv2.VideoWriter(raw_output_path, cv2.VideoWriter_fourcc(*'mp4v'), fps, (width, height))
 
+        processor = SquatProcessor()
+
         while cap.isOpened():
             ret, frame = cap.read()
             if not ret:
                 break
             frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
-            processed_frame, _ = squat_processor.process(frame_rgb, pose)
+            processed_frame, _ = processor.process(frame_rgb, pose)
             writer.write(processed_frame[..., ::-1])
 
         cap.release()
         writer.release()
-        os.remove(temp_input_path)
+        os.remove(input_path)
 
         h264_output_path = tempfile.NamedTemporaryFile(delete=False, suffix=".mp4").name
         subprocess.run([
@@ -49,8 +57,35 @@ async def analyze_squat(video: UploadFile = File(...)):
         return FileResponse(
             path=h264_output_path,
             media_type="video/mp4",
-            filename="squat_processed.mp4"
+            filename="squat_annotated_output.mp4"
         )
+
+    except Exception as e:
+        return JSONResponse(status_code=500, content={"error": str(e)})
+
+
+@router.post("/analyze-frame")
+async def analyze_squat_frame(payload: FramePayload):
+    try:
+        session_id = payload.session_id
+
+        img_data = base64.b64decode(payload.image)
+        np_arr = np.frombuffer(img_data, np.uint8)
+        frame = cv2.imdecode(np_arr, cv2.IMREAD_COLOR)
+        frame_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+
+        if session_id not in session_store:
+            session_store[session_id] = SquatProcessor()
+        processor = session_store[session_id]
+
+        processed_frame, _ = processor.process(frame_rgb, pose)
+
+        processed_bgr = processed_frame[..., ::-1]
+        success, buffer = cv2.imencode('.jpg', processed_bgr)
+        if not success:
+            raise ValueError("Failed to encode frame")
+
+        return Response(content=buffer.tobytes(), media_type="image/jpeg")
 
     except Exception as e:
         return JSONResponse(status_code=500, content={"error": str(e)})

--- a/core/processors/squat_processor.py
+++ b/core/processors/squat_processor.py
@@ -14,13 +14,14 @@ class SquatProcessor(BasePoseProcessor):
             feedback, left_angle, right_angle = analyze_squat_posture(
                 results.pose_landmarks.landmark, frame.shape)
 
-            # Rep logic (down → up)
-            if left_angle > 160 and right_angle > 160:
+            # Determine squat state and rep transitions
+            if left_angle > 140 and right_angle > 140:
                 if self.last_state == 'down':
                     self.rep_count += 1
                     self.last_state = 'up'
-            elif left_angle < 100 and right_angle < 100:
-                self.last_state = 'down'
+            elif left_angle < 90 and right_angle < 90:
+                if self.last_state != 'down':
+                    self.last_state = 'down'
 
         frame = self.draw_feedback(frame, feedback)
         return frame, feedback

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,6 @@ services:
     container_name: streamlit-frontend
     depends_on:
       - backend
+    devices:
+      - "/dev/video0:/dev/video0"
+    privileged: true   

--- a/frontend/pages/3_live_video_analysis.py
+++ b/frontend/pages/3_live_video_analysis.py
@@ -1,0 +1,60 @@
+import streamlit as st
+import av
+import cv2
+import numpy as np
+import requests
+import base64
+import uuid
+from streamlit_webrtc import webrtc_streamer, RTCConfiguration, VideoProcessorBase
+
+API_ENDPOINTS = {
+    "Squat": "http://backend:8000/squat/analyze-frame",
+    "Lateral Raise": "http://backend:8000/lateral/analyze-frame"
+}
+
+st.title("📡 Live Pose Analysis via API")
+exercise = st.selectbox("Choose Exercise", list(API_ENDPOINTS.keys()))
+api_url = API_ENDPOINTS[exercise]
+frame_interval = 10
+
+class PoseAnalyzerViaAPI(VideoProcessorBase):
+    def __init__(self, api_url):
+        self.frame_count = 0
+        self.last_response = None
+        self.session_id = str(uuid.uuid4())
+        self.api_url = api_url
+        self.session = requests.Session()
+
+    def recv(self, frame: av.VideoFrame) -> av.VideoFrame:
+        self.frame_count += 1
+        img = frame.to_ndarray(format="bgr24")
+        resized = cv2.resize(img, (320, 240))
+
+        if self.frame_count % frame_interval == 0:
+            _, img_encoded = cv2.imencode(".jpg", resized, [int(cv2.IMWRITE_JPEG_QUALITY), 70])
+            img_base64 = base64.b64encode(img_encoded).decode("utf-8")
+            payload = {"session_id": self.session_id, "image": img_base64}
+
+            try:
+                response = self.session.post(self.api_url, json=payload, timeout=5)
+                if response.status_code == 200:
+                    self.last_response = response.content
+            except Exception as e:
+                print(f"❌ Request error: {e}")
+
+        if self.last_response:
+            decoded = cv2.imdecode(np.frombuffer(self.last_response, np.uint8), cv2.IMREAD_COLOR)
+            if decoded is not None:
+                return av.VideoFrame.from_ndarray(decoded, format="bgr24")
+
+        return av.VideoFrame.from_ndarray(img, format="bgr24")
+
+webrtc_streamer(
+    key="api-live-analysis",
+    video_processor_factory=lambda: PoseAnalyzerViaAPI(api_url),
+    rtc_configuration=RTCConfiguration({
+        "iceServers": [{"urls": ["stun:stun.l.google.com:19302"]}]
+    }),
+    media_stream_constraints={"video": True, "audio": False},
+    async_processing=True
+)


### PR DESCRIPTION
- Added support for real-time (live) video frame analysis for both lateral raises and squats using base64-encoded input.
- Implemented session-based processing to maintain rep counts and state across frames.
- Fixed an issue with cv2 frame color handling to ensure consistent BGR ↔ RGB conversion for accurate pose detection and overlay rendering.
- Remove redundant cv2.putText() call for rep count in lateral raises.
